### PR TITLE
Add a raw height

### DIFF
--- a/src/assets/sass/components/projects/_projectDetails.scss
+++ b/src/assets/sass/components/projects/_projectDetails.scss
@@ -6,10 +6,17 @@
     position: relative;
 
     .carrousel {
+        overflow: hidden;
+
         .carrousel-img-container {
+            width: 600px;
+            height: 400px;
             margin-bottom: 20px;
             
             .carrousel-img {
+                width: 100%;
+                height: 100%;
+                object-fit: cover;
                 border-radius: 8px;
             }
             .display {


### PR DESCRIPTION
When we slided image, there was sometimes a jump. The image disappeared and the text took its place to came back at his place in a fraction of a second.
Had a raw height to the img-container fix this bug